### PR TITLE
Minor fix.

### DIFF
--- a/NetworkEncrypted/EncryptedChannelClient.cs
+++ b/NetworkEncrypted/EncryptedChannelClient.cs
@@ -75,7 +75,11 @@ namespace NetworkEncrypted
         private void OnDisable()
         {
             // Stop listening if this behavior is disabled by the user.
-            InstanceFinder.ClientManager.OnClientConnectionState -= OnClientConnectionState;
+            ClientManager clientManager = InstanceFinder.ClientManager;
+            if (clientManager != null)
+            {
+                clientManager.OnClientConnectionState -= OnClientConnectionState;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
After stopping the app, client manager may become null sooner than OnDisable() in EncryptedChannelClient.cs, which will cause an exception.

This exception doesn't have any harm as the app is stopped anyway, but it is annoying to see it in logs every time.